### PR TITLE
change IBM_CLOUD_API_KEY to secure

### DIFF
--- a/.bluemix/demodra.pipeline.yml
+++ b/.bluemix/demodra.pipeline.yml
@@ -16,7 +16,7 @@ stages:
     type: text
   - name: IBM_CLOUD_API_KEY
     value: ${INSIGHTS_API_KEY}
-    type: text
+    type: secure
   jobs:
   - name: Build
     type: builder
@@ -74,7 +74,7 @@ stages:
     type: text
   - name: IBM_CLOUD_API_KEY
     value: ${INSIGHTS_API_KEY}
-    type: text
+    type: secure
   jobs:
   - name: Deploy
     type: deployer
@@ -126,7 +126,7 @@ stages:
     type: text
   - name: IBM_CLOUD_API_KEY
     value: ${INSIGHTS_API_KEY}
-    type: text
+    type: secure
   jobs:
   - name: Gate
     type: tester


### PR DESCRIPTION
Should we set the API Key to be secure in the properties?  This will prevent it from being seen as clear text when viewing properties.